### PR TITLE
Allow disabling of js file sorting

### DIFF
--- a/src/tureki/PhpCc.php
+++ b/src/tureki/PhpCc.php
@@ -38,7 +38,8 @@ class PhpCc {
 			'jar_file'     => __DIR__.'/vendor/closure-compiler/compiler.jar', 
 			'output_path'  => '/',
 			'optimization' => 'SIMPLE_OPTIMIZATIONS',
-			'charset'      => 'utf-8'
+			'charset'      => 'utf-8',
+			'sort'         => true,
 		);
 
 		$this->options = array_merge($this->options,$options);
@@ -127,7 +128,11 @@ class PhpCc {
 
 			$this->js_files = array_unique($this->js_files);
 			
-			sort($this->js_files);
+			$opt        = $this->_get_options();
+
+            if ($opt['sort']) {
+    			sort($this->js_files);
+            }
 			
 			$num_js         = count($this->js_files);
 

--- a/src/tureki/PhpCc.php
+++ b/src/tureki/PhpCc.php
@@ -130,9 +130,9 @@ class PhpCc {
 			
 			$opt        = $this->_get_options();
 
-            if ($opt['sort']) {
-    			sort($this->js_files);
-            }
+			if ($opt['sort']) {
+				sort($this->js_files);
+			}
 			
 			$num_js         = count($this->js_files);
 


### PR DESCRIPTION
I have a couple modules in my project that can't handle being loaded out of order, while I am working on correcting that in the long run for the meantime I need them to load in the order I specify them. I added a new option 'sort' that defaults to true, if it is set to false then the sort() call on the js file array never gets called.
